### PR TITLE
Update of IconFontGenerator.php for Aramaic svg files

### DIFF
--- a/src/MadeYourDay/SVG/IconFontGenerator.php
+++ b/src/MadeYourDay/SVG/IconFontGenerator.php
@@ -239,14 +239,16 @@ class IconFontGenerator{
 	 * @return string       unicode hex representation of the character
 	 */
 	public static function unicodeToHex($char){
-
 		if(!is_string($char) || mb_strlen($char, 'utf-8') !== 1){
-			throw new \InvalidArgumentException('$char must be one single character');
+			//throw new \InvalidArgumentException('$char must be one single character: '. print_r($char, true));
+			$unicode = unpack('N', mb_convert_encoding(print_r($char, true), 'UCS-4BE', 'UTF-8'));
+			if(empty($unicode[1])){
+				return dechex(print_r($char, true));
+			}
+			return dechex($unicode[1]);
 		}
-
 		$unicode = unpack('N', mb_convert_encoding($char, 'UCS-4BE', 'UTF-8'));
 		return dechex($unicode[1]);
-
 	}
 
 	/**


### PR DESCRIPTION
Tested with Estrangelo Edessa v 5.00 included in Windows by Microsoft and the Syriac Computing Institute and allows writing non standard files names such us uni072A0308-isol-xÜŞĚ.svg etc. Should work with Syriac Commercial Fonts of Beth Mardutho Institute.